### PR TITLE
Updated files for release 1.0.62

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2hash (1.0.62) trusty; urgency=low
+
+  * Fixed fatal error in destructing mmap info and etc
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Thu, 04 Oct 2018 13:23:50 +0900
+
 k2hash (1.0.61) trusty; urgency=low
 
   * avoid static object initialization order problem(SIOF)

--- a/lib/k2hfilemonitor.h
+++ b/lib/k2hfilemonitor.h
@@ -103,6 +103,7 @@ class K2HFileMonitor
 		bool UpdateArea(bool& is_need_check);
 
 	private:
+		bool CloseOnlyFile(void);
 		bool InitializeFileMonitor(PSFMONWRAP pfmonwrap, bool noupdate);
 
 		bool CheckInode(bool& is_change, bool valupdate);

--- a/lib/k2hmmapinfo.cc
+++ b/lib/k2hmmapinfo.cc
@@ -49,14 +49,18 @@ K2HMmapMan::K2HMmapMan() : lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED)
 
 K2HMmapMan::~K2HMmapMan()
 {
-	for(k2hfmapgrps_t::const_iterator iter = fmapgrps.begin(); iter != fmapgrps.end(); ++iter){
-		PK2HMMAPGRP	pmmapgrp = iter->second;
+	Lock();
+	for(k2hfmapgrps_t::iterator iter = fmapgrps.begin(); iter != fmapgrps.end(); fmapgrps.erase(iter++)){
+		PK2HMMAPGRP	pmmapgrp= iter->second;
+		iter->second		= NULL;
 		K2H_Delete(pmmapgrp);
 	}
-	for(k2homapgrps_t::const_iterator iter = omapgrps.begin(); iter != omapgrps.end(); ++iter){
-		PK2HMMAPGRP	pmmapgrp = iter->second;
+	for(k2homapgrps_t::iterator iter = omapgrps.begin(); iter != omapgrps.end(); omapgrps.erase(iter++)){
+		PK2HMMAPGRP	pmmapgrp= iter->second;
+		iter->second		= NULL;
 		K2H_Delete(pmmapgrp);
 	}
+	Unlock();
 }
 
 //---------------------------------------------------------
@@ -198,7 +202,9 @@ bool K2HMmapMan::RemoveMapInfo(const K2HShm* pk2hshm, const char* file, bool nee
 			// always remove map info
 			MSG_K2HPRN("Destroy mapping info for for K2HShm(%p).", pk2hshm);
 
-			K2H_Delete(iter->second);
+			PK2HMMAPGRP	pmmapgrp= iter->second;
+			iter->second		= NULL;
+			K2H_Delete(pmmapgrp);
 			omapgrps.erase(iter);
 		}
 
@@ -217,7 +223,9 @@ bool K2HMmapMan::RemoveMapInfo(const K2HShm* pk2hshm, const char* file, bool nee
 					K2H_CLOSE(iter->second->fd);
 					K2HLock::RemoveReadModeFd(iter->second->fd);
 				}
-				K2H_Delete(iter->second);
+				PK2HMMAPGRP	pmmapgrp= iter->second;
+				iter->second		= NULL;
+				K2H_Delete(pmmapgrp);
 				fmapgrps.erase(iter);
 			}
 		}
@@ -271,7 +279,9 @@ void K2HMmapMan::UnmapAll(const K2HShm* pk2hshm, const char* file, bool needlock
 			if(1 != iter->second->refcnt){
 				ERR_K2HPRN("map info reference count for K2HShm(%p) is not 1, should always be 1.", pk2hshm);
 			}
-			K2H_Delete(iter->second);		// unmap all in destructor
+			PK2HMMAPGRP	pmmapgrp= iter->second;
+			iter->second		= NULL;
+			K2H_Delete(pmmapgrp);			// unmap all in destructor
 			omapgrps.erase(iter);
 		}
 
@@ -296,7 +306,9 @@ void K2HMmapMan::UnmapAll(const K2HShm* pk2hshm, const char* file, bool needlock
 					K2H_CLOSE(iter->second->fd);
 					K2HLock::RemoveReadModeFd(iter->second->fd);
 				}
-				K2H_Delete(iter->second);	// unmap all in destructor
+				PK2HMMAPGRP	pmmapgrp= iter->second;
+				iter->second		= NULL;
+				K2H_Delete(pmmapgrp);		// unmap all in destructor
 				fmapgrps.erase(iter);
 			}
 		}


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.61 to 1.0.62

#### 1.0.62
- Fixed fatal error in destructing mmap info and etc 
  **(1) Segmentation Fault in mapping information destruction to mmap information**  
Since the modification of v1.0.61( **avoid static object initialization order problem(SIOF)** ), rarely a segmantation fault occurred when the single object of K2HMmapMan was destroyed.  
A defect in the destructor of the K2HMmapMan class appeared by it, and a segmentation fault occurred.  
This bug was corrected.
  **(2) MonitorFile class closed invalid fd**  
The v1.0.59( **Fixed a bug about dead loop** ) was insufficient, and potential problems still existed in the initialization method.  
And the MonitorFile class had a problem of closing invalid fd.  
We reviewed DeadLoop countermeasure and fixed this problem.

