### PR TITLE
Updated files for release 1.0.63

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+k2hash (1.0.63) trusty; urgency=low
+
+  * Fixed requires in specfile
+  * Fixed fatal error in destructor code corresponding to SIOF etc
+
+ -- Takeshi Nakatani <ggtakec@gmail.com> Wed, 17 Oct 2018 12:42:43 +0900
+
 k2hash (1.0.62) trusty; urgency=low
 
   * Fixed fatal error in destructing mmap info and etc

--- a/buildutils/k2hash.spec.in
+++ b/buildutils/k2hash.spec.in
@@ -50,6 +50,7 @@ License: @PKGLICENSE@
 Group: Applications/Databases
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
+Requires: libfullock%{?_isa} >= 1.0.28
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: git-core gcc-c++ make libtool libfullock-devel%{?_isa} >= 1.0.28
 Prefix: %{_prefix}

--- a/lib/k2hattrbuiltin.cc
+++ b/lib/k2hattrbuiltin.cc
@@ -206,7 +206,8 @@ bool K2hAttrBuiltin::CleanAttrBuiltin(const K2HShm* pshm)
 		return true;	// already unload
 	}
 
-	PK2HBATTRPACK	pPack = iter->second;
+	PK2HBATTRPACK	pPack	= iter->second;
+	iter->second			= NULL;
 	K2H_Delete(pPack);
 	K2hAttrBuiltin::GetAttrPackMap().erase(iter);
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.62 to 1.0.63

#### 1.0.63
- Fixed requires in specfile
  Added requires keyword in spec file for dependent packages.
-  Fixed fatal error in destructor code corresponding to SIOF etc
  Fixed segmentation Fault in destructor  code again.
  Since the modification of v1.0.61( **avoid static object initialization order problem(SIOF)** ), rarely a segmantation fault occurred when the single object of std::map etc was destroyed.  