### PR TITLE
Updated files for release 1.0.64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2hash (1.0.64) trusty; urgency=low
+
+  * Fixed a bug segmentation fault exiting tr thread
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 07 Nov 2018 10:11:02 +0900
+
 k2hash (1.0.63) trusty; urgency=low
 
   * Fixed requires in specfile

--- a/lib/k2htrans.cc
+++ b/lib/k2htrans.cc
@@ -730,7 +730,7 @@ bool K2HTransManager::ExitThreads(const K2HShm* pk2hshm)
 	while(!fullock::flck_trylock_noshared_mutex(&LockPool));	// no call sched_yield()
 
 	trpoolmap_t::iterator	iter;
-	if(trpoolmap.end() == (iter = trpoolmap.find(pk2hshm)) && !iter->second){
+	if(trpoolmap.end() == (iter = trpoolmap.find(pk2hshm)) || !iter->second){
 		MSG_K2HPRN("There is no thread running for target.");
 		fullock::flck_unlock_noshared_mutex(&LockPool);
 		return true;


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.63 to 1.0.64

#### 1.0.64
- Fixed a bug segmentation fault exiting tr thread
  The following problem occurs after changing the setting of Transaction Thread Pool.
  When detaching k2hash or starting transaction, termination processing of transaction thread is performed. And sengmentation fault occurred at this time.
  This bug has been fixed.
