### PR TITLE
Avoid virtual method calls in destructor.

### DIFF
--- a/lib/k2hattrbuiltin.h
+++ b/lib/k2hattrbuiltin.h
@@ -152,7 +152,7 @@ class K2hAttrBuiltin : public K2hAttrOpsBase
 		virtual ~K2hAttrBuiltin(void);
 
 		virtual int GetType(void) const { return TYPE_ATTRBUILTIN; }
-		virtual void Clear(void);
+		void Clear(void);
 		virtual bool IsHandleAttr(const unsigned char* key, size_t keylen) const;
 		virtual bool UpdateAttr(K2HAttrs& attrs);
 		virtual void GetInfo(std::stringstream& ss) const;

--- a/lib/k2hattrop.cc
+++ b/lib/k2hattrop.cc
@@ -65,7 +65,7 @@ K2hAttrOpsBase::K2hAttrOpsBase(void) : VerInfo(""), byKey(NULL), KeyLen(0), byVa
 
 K2hAttrOpsBase::~K2hAttrOpsBase(void)
 {
-	K2hAttrOpsBase::Clear();
+	Clear();
 }
 
 void K2hAttrOpsBase::Clear(void)
@@ -82,7 +82,7 @@ bool K2hAttrOpsBase::Set(const unsigned char* pkey, size_t key_len, const unsign
 	// [NOTE]
 	// Clear only this class member.
 	//
-	K2hAttrOpsBase::Clear();
+	Clear();
 
 	if(pkey && 0 < key_len){
 		byKey	= pkey;

--- a/lib/k2hattrop.h
+++ b/lib/k2hattrop.h
@@ -71,7 +71,7 @@ class K2hAttrOpsBase
 		virtual ~K2hAttrOpsBase(void);
 
 		virtual int GetType(void) const { return TYPE_ATTROP; }
-		virtual void Clear(void);
+		void Clear(void);
 		virtual bool IsHandleAttr(const char* key) const;
 		virtual bool IsHandleAttr(const unsigned char* key, size_t keylen) const = 0;
 		virtual bool UpdateAttr(K2HAttrs& attrs) = 0;

--- a/lib/k2hpage.h
+++ b/lib/k2hpage.h
@@ -62,10 +62,10 @@ class K2HPage
 
 		virtual bool Free(PPAGEHEAD* ppRelLastPageHead, unsigned long* pPageCount, bool isAllPage) = 0;
 
-		virtual void Clean(void);
+		void Clean(void);
 		void CleanMemory(void);
-		virtual void CleanPageHead(void);
-		virtual void CleanLoadedData(void);
+		void CleanPageHead(void);
+		void CleanLoadedData(void);
 
 	public:
 		K2HPage(const K2HShm* pk2hshm = NULL);

--- a/lib/k2hpagefile.h
+++ b/lib/k2hpagefile.h
@@ -36,8 +36,8 @@ class K2HPageFile : public K2HPage
 	protected:
 		K2HPageFile(const K2HShm* pk2hshm, int fd, off_t offset, bool nodup);
 
-		virtual void Clean(void);
-		virtual void CleanPageHead(void);
+		void Clean(void);
+		void CleanPageHead(void);
 		bool CloseFd(void);
 		bool DuplicateFd(int fd);
 


### PR DESCRIPTION
#### Relevant Issue (if applicable)
(If there are Issues related to this PullRequest, please list it.)

#### Details

- Avoided virtual method calls in destructor of these classes.
  - K2hAttrOpsBase
  - K2hAttrBuiltin
  - K2HPage
  - K2HPageMem
  - K2HPageFile