### PR TITLE
Allow 0 sec for expire when setting directly as placeholder

### DIFF
--- a/lib/k2hattrbuiltin.cc
+++ b/lib/k2hattrbuiltin.cc
@@ -518,10 +518,19 @@ bool K2hAttrBuiltin::Set(const K2HShm* pshm, const char* encpass, const time_t* 
 		EncPass = encpass;
 	}
 	if(expire){
-		if(*expire <= 0){
-			ERR_K2HPRN("expire(%zd) must be over 0.", *expire);
+		// [NOTE]
+		// It is allowed to set the expire value directly to 0.
+		// This is useful if you want to create keys as placeholders and so on.
+		// However, the expire value can be set 0 only when this method is
+		// called directly.
+		//
+		if(*expire < 0){
+			ERR_K2HPRN("expire(%zd) must be 0 or over 0.", *expire);
 			Clear();
 			return false;
+		}
+		if(*expire == 0){
+			MSG_K2HPRN("expire(%zd) is allowed, it means placeholder.", *expire);
 		}
 		ExpireSec = *expire;
 	}

--- a/tests/k2hlinetool.cc
+++ b/tests/k2hlinetool.cc
@@ -1342,6 +1342,16 @@ static bool SetCommand(K2HShm& k2hash, params_t& params)
 		}
 	}
 
+	// [NOTE]
+	// It is allowed to set the expire value directly to 0.
+	// This is useful if you want to create keys as placeholders and so on.
+	// However, the expire value can be set 0 only when this method is
+	// called directly.
+	//
+	if(0 == expire_time){
+		PRN("[MSG] The expire value is 0. This means that this key is specifically allowed as a placeholder.");
+	}
+
 	if(isModeCAPI){
 		if(isRemoveSubkeyAll){
 			if(!k2h_set_str_all_wa(reinterpret_cast<k2h_h>(&k2hash), params[0].c_str(), pValue, NULL, (PassPhrase.empty() ? NULL : PassPhrase.c_str()), (expire_time <= 0 ? NULL : &expire_time))){


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Changed to allow key creation with expire set to 0.
(For queue, keyqueue, and transaction data, keep expire=0 not allowed.)
And changed to allow expire=0 only for the set command in k2hlinetool.
