### PR TITLE
Updated files for release 1.0.78

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2hash (1.0.78) trusty; urgency=low
+
+  * Fixed centos8 build and removed centos6 build - #47
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 16 Dec 2020 11:43:31 +0900
+
 k2hash (1.0.77) trusty; urgency=low
 
   * Fixed a error by cppcheck 2.2 - #45


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.77 to 1.0.78
- Fixed centos8 build and removed centos6 build - #47

