### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/build.md
+++ b/build.md
@@ -51,7 +51,7 @@ Table1. Development packages to build the [K2HASH](https://k2hash.antpick.ax/):
 | [GnuTLS](https://gnutls.org/) (nettle) | nettle-dev(deb) |
 | [Mozilla NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS) | nss-devel(rpm) |
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below. You can replace `libgcrypt11-dev` with the other SSL/TLS package your application requires:
+For recent Debian-based Linux distributions users, follow the steps below: You can replace `libgcrypt11-dev` with the other SSL/TLS package your application requires:
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -62,7 +62,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below. You can replace `nss-devel` with the other SSL/TLS package your application requires:
+For users who use supported Fedora other than latest version, follow the steps below: You can replace `nss-devel` with the other SSL/TLS package your application requires:
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel nss-devel -y
+$ sudo dnf install git -y
+```
+
+For other recent RPM-based Linux distributions users, follow the steps below: You can replace `nss-devel` with the other SSL/TLS package your application requires:
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y
@@ -95,7 +106,7 @@ Table1. possible configure option:
 | [GnuTLS](https://gnutls.org/) (nettle) | ./configure \-\-prefix=/usr \-\-with-nettle | ./configure \-\-prefix=/usr \-\-with-gnutls |
 | [Mozilla NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS) | ./configure \-\-prefix=/usr \-\-with-nss | ./configure \-\-prefix=/usr \-\-with-nss |
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below:
+For recent Debian-based Linux distributions users, follow the steps below:
 ```bash
 $ cd k2hash
 $ sh autogen.sh
@@ -104,7 +115,7 @@ $ make
 $ sudo make install
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below:
+For other recent RPM-based Linux distributions users, follow the steps below:
 ```bash
 $ cd k2hash
 $ sh autogen.sh

--- a/buildja.md
+++ b/buildja.md
@@ -50,7 +50,7 @@ next_string: Developer
 | [GnuTLS](https://gnutls.org/) (nettle) | nettle-dev(deb) |
 | [Mozilla NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS) | nss-devel(rpm) |
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。SSL/TLSライブラリとヘッダファイルのパッケージ名（libgcrypt11-dev）は、あなたアプリケーションが要求するSSL/TLSライブラリとヘッダファイルのパッケージ名と置き換えても良いです。
+最近のDebianベースLinuxの利用者は、以下の手順に従ってください。SSL/TLSライブラリとヘッダファイルのパッケージ名（libgcrypt11-dev）は、あなたアプリケーションが要求するSSL/TLSライブラリとヘッダファイルのパッケージ名と置き換えても良いです。
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -61,7 +61,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。SSL/TLSライブラリとヘッダファイルのパッケージ名（nss-devel）は、あなたアプリケーションが要求するSSL/TLSライブラリとヘッダファイルのパッケージ名と置き換えても良いです。
+Fedoraの利用者は、以下の手順に従ってください。SSL/TLSライブラリとヘッダファイルのパッケージ名（nss-devel）は、あなたアプリケーションが要求するSSL/TLSライブラリとヘッダファイルのパッケージ名と置き換えても良いです。
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel nss-devel -y
+$ sudo dnf install git -y
+```
+
+その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。SSL/TLSライブラリとヘッダファイルのパッケージ名（nss-devel）は、あなたアプリケーションが要求するSSL/TLSライブラリとヘッダファイルのパッケージ名と置き換えても良いです。
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y
@@ -94,7 +105,7 @@ $ git clone https://github.com/yahoojapan/k2hash.git
 | [GnuTLS](https://gnutls.org/) (nettle)| ./configure \-\-prefix=/usr \-\-with-nettle | ./configure \-\-prefix=/usr \-\-with-gnutls |
 | [Mozilla NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS) | ./configure \-\-prefix=/usr \-\-with-nss | ./configure \-\-prefix=/usr \-\-with-nss |
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。
+最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```bash
 $ cd k2hash
 $ sh autogen.sh
@@ -103,7 +114,7 @@ $ make
 $ sudo make install
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。
+その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```bash
 $ cd k2hash
 $ sh autogen.sh

--- a/feature.md
+++ b/feature.md
@@ -15,6 +15,9 @@ next_string: Usage
 
 # Feature
 
+## Flexible installation
+We provide suitable K2HASH installation for your OS. If you use Ubuntu, CentOS, Fedora or Debian, you can easily install it from [packagecloud.io] (https://packagecloud.io/antpickax/stable). Even if you use none of them, you can use it by [Build] (https://k2hash.antpick.ax/build.html) by yourself.
+
 ## Sub Key
 The most characteristic of K2HASH is Sub-Key, K2HASH can not only store a value corresponding to a key, but also link another key as a child to the key.  
 In other words, K2HASH can create a parent-child relationship between Key(the key) and Sub-Key(another key).  

--- a/featureja.md
+++ b/featureja.md
@@ -15,6 +15,9 @@ next_string: Usage
 
 # 特徴
 
+## 柔軟なインストール
+K2HASHは、あなたのOSに応じて、柔軟にインストールが可能です。あなたのOSが、Ubuntu、CentOS、Fedora、Debianなら、[packagecloud.io](https://packagecloud.io/antpickax/stable)からソースコードをビルドすることなく、簡単にインストールできます。それ以外のOSであっても、自身で[ビルド](https://k2hash.antpick.ax/buildja.html)して使うことができます。
+
 ## キーとサブキー
 K2HASHの一番の特徴は、キーに対して値を保持するKVSの機能に、キーに対してサブキーを紐付けることができます。  
 つまり、キーとキーに相関関係（親子関係）を持つことができ、この相関関係をライブラリレベルでサポートします。  

--- a/usage.md
+++ b/usage.md
@@ -27,7 +27,7 @@ The **K2HASH** publishes [packages](https://packagecloud.io/app/antpickax/stable
 The package of the **K2HASH** is released in the form of Debian package, RPM package.  
 Since the installation method differs depending on your OS, please check the following procedure and install it.  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -39,7 +39,19 @@ To install the developer package, please install the following package.
 $ sudo apt-get install k2hash-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2hash
+```
+To install the developer package, please install the following package.
+```
+$ sudo dnf install k2hash-devel
+```
+
+#### For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/usageja.md
+++ b/usageja.md
@@ -28,7 +28,7 @@ K2HASHの実行環境を整え、動作確認する方法を示します。
 **K2HASH** のパッケージは、Debianパッケージ、RPMパッケージの形式で公開しています。  
 お使いのOSによりインストール方法が異なりますので、以下の手順を確認してインストールしてください。  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### 最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -40,7 +40,19 @@ $ sudo apt-get install k2hash
 $ sudo apt-get install k2hash-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2hash
+```
+開発者向けパッケージをインストールする場合は、以下のパッケージをインストールしてください。
+```
+$ sudo dnf install k2hash-devel
+```
+
+#### その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from the manuals.