### PR TITLE
Replaces libgcrypt11 with libgcrypt20

### DIFF
--- a/build.md
+++ b/build.md
@@ -47,18 +47,18 @@ Table1. Development packages to build the [K2HASH](https://k2hash.antpick.ax/):
 | SSL/TLS library | pkg |
 |:--|:--|
 | [OpenSSL](https://www.openssl.org/) | libssl-dev(deb) / openssl-devel(rpm) |
-| [GnuTLS](https://gnutls.org/) (gcrypt) | libgcrypt11-dev(deb) |
+| [GnuTLS](https://gnutls.org/) (gcrypt) | libgcrypt20-dev(deb) |
 | [GnuTLS](https://gnutls.org/) (nettle) | nettle-dev(deb) |
 | [Mozilla NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS) | nss-devel(rpm) |
 
-For recent Debian-based Linux distributions users, follow the steps below: You can replace `libgcrypt11-dev` with the other SSL/TLS package your application requires:
+For recent Debian-based Linux distributions users, follow the steps below: You can replace `libgcrypt20-dev` with the other SSL/TLS package your application requires:
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
 $ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.deb.sh \
     | sudo bash
 $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-config \
-    libyaml-dev libfullock-dev libgcrypt11-dev -y
+    libyaml-dev libfullock-dev libgcrypt20-dev -y
 $ sudo apt-get install git -y
 ```
 

--- a/feature.md
+++ b/feature.md
@@ -16,7 +16,7 @@ next_string: Usage
 # Feature
 
 ## Flexible installation
-We provide suitable K2HASH installation for your OS. If you use Ubuntu, CentOS, Fedora or Debian, you can easily install it from [packagecloud.io] (https://packagecloud.io/antpickax/stable). Even if you use none of them, you can use it by [Build] (https://k2hash.antpick.ax/build.html) by yourself.
+We provide suitable K2HASH installation for your OS. If you use Ubuntu, CentOS, Fedora or Debian, you can easily install it from [packagecloud.io](https://packagecloud.io/antpickax/stable). Even if you use none of them, you can use it by [Build](https://k2hash.antpick.ax/build.html) by yourself.
 
 ## Sub Key
 The most characteristic of K2HASH is Sub-Key, K2HASH can not only store a value corresponding to a key, but also link another key as a child to the key.  


### PR DESCRIPTION
#### Relevant Issue (if applicable)
N/A

#### Details
This PR replaces libgcrypt11 with libgcrypt20

