### PR TITLE
Fixed to create /var/lib/antpickax at installation

### DIFF
--- a/buildutils/k2hash.postinst
+++ b/buildutils/k2hash.postinst
@@ -1,9 +1,8 @@
-#
-# K2HASH
+#!/bin/sh
 #
 # Utility tools for building configure/packages by AntPickax
 #
-# Copyright 2018 Yahoo Japan Corporation.
+# Copyright 2021 Yahoo Japan Corporation.
 #
 # AntPickax provides utility tools for supporting autotools
 # builds.
@@ -14,27 +13,26 @@
 # These tools were recreated to reduce the number of fixes and
 # reduce the workload of developers when there is a change in
 # the project configuration.
-#
+# 
 # For the full copyright and license information, please view
 # the license file that was distributed with this source code.
 #
 # AUTHOR:   Takeshi Nakatani
-# CREATE:   Fri, Apr 13 2018
+# CREATE:   Mon, Aug 16 2021
 # REVISION:
 #
 
-EXTRA_DIST =make_variables.sh \
-			make_release_version_file.sh \
-			make_commit_hash.sh \
-			make_commit_hash_source.sh \
-			make_rpm_changelog.sh \
-			make_description.sh \
-			debian_build.sh \
-			rpm_build.sh \
-			k2hash.postinst
+#
+# Create /var/lib/antpickax directory
+#
+mkdir -p /var/lib/antpickax
+chmod 0777 /var/lib/antpickax
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: expandtab sw=4 ts=4 fdm=marker
+# vim<600: expandtab sw=4 ts=4
 #

--- a/buildutils/k2hash.spec.in
+++ b/buildutils/k2hash.spec.in
@@ -67,6 +67,7 @@ BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.35
 %install
 %make_install
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
+mkdir -p %{buildroot}/var/lib/antpickax
 
 %if %{make_check}
 %check
@@ -96,6 +97,7 @@ rm -rf %{buildroot}
 %{_libdir}/*.so.1*
 %{_mandir}/man1/*
 %{_bindir}/*
+%dir %attr(0777,root,root) /var/lib/antpickax
 
 #
 # devel package


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Changed the package to create a `/var/lib/antpickax` directory.

