### PR TITLE
Updates ChangeLog for 1.0.81

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2hash (1.0.81) trusty; urgency=low
+
+  * Fixed to create /var/lib/antpickax at installation - #59
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Mon, 16 Aug 2021 10:20:24 +0900
+
 k2hash (1.0.80) trusty; urgency=low
 
   * Added docker build and push in Github Actions - #57


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.80 to 1.0.81
- Fixed to create /var/lib/antpickax at installation - #59
