### PR TITLE
Enabled external customization of configure.ac and fixed for building

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -158,6 +158,11 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" -o "X${CI_OSTYPE}" = "Xcentos:centos8" ]; t
 	# special variables
 	export K2HATTR_ENC_TYPE=AES256_PBKDF2
 
+	#
+	# Change mirrorlist
+	#
+	sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+
 elif [ "X${CI_OSTYPE}" = "Xcentos:7" -o "X${CI_OSTYPE}" = "Xcentos:centos7" ]; then
 	DIST_TAG="el/7"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libfullock-devel nss-devel"

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@
 
 SUBDIRS=lib docs tests buildutils
 
-EXTRA_DIST=RELEASE_VERSION
+EXTRA_DIST=RELEASE_VERSION @CONFIGURECUSTOM@
 
 CPPCHECK_CMD=	cppcheck
 CPPCHECK_OPT=	--quiet \
@@ -36,7 +36,10 @@ cppcheck:
 	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/configure.ac
+++ b/configure.ac
@@ -82,15 +82,40 @@ AC_CHECK_FUNCS([fdatasync ftruncate gettimeofday memset munmap realpath strcasec
 AC_CONFIG_MACRO_DIR([m4])
 
 #
+# Load customizable variables
+#
+AC_CHECK_FILE([configure.custom],
+	[
+		configure_custom_file="configure.custom"
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		configure_custom_file=""
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="fullock"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax@mail.yahoo.co.jp"
+		custom_dev_name="FULLOCK_DEVELOPER"
+	]
+)
+
+#
 # Symbols for buildutils
 #
-AC_SUBST([GIT_DOMAIN], "github.com")
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "k2hash")
-AC_SUBST([CURRENTREV], "`$(pwd)/buildutils/make_commit_hash.sh -o yahoojapan -r k2hash -short`")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-K2HASH_DEVELOPER}`")
-
+AC_SUBST([CONFIGURECUSTOM], "${configure_custom_file}")
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([CURRENTREV], "$($(pwd)/buildutils/make_commit_hash.sh -o yjcore -r fullock -ep "${custom_git_endpoint}" -short)")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
+#
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hash.1 -short`")
 AC_SUBST([LONGDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hash.1 -long`")
@@ -294,7 +319,10 @@ AC_CONFIG_FILES([Makefile
 AC_OUTPUT
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -124,8 +124,14 @@ endif
 libk2hash_la_LDFLAGS= -version-info $(LIB_VERSION_INFO)
 libk2hash_la_LIBADD	= $(fullock_LIBS) $(CRYPT_LIBS) -lrt -lpthread
 
-AM_CFLAGS			= -DK2HASH
-AM_CPPFLAGS			= -DK2HASH
+# [NOTE]
+# "-Waddress-of-packed-member" optsion was introduced by default
+# from GCC 9.
+# Knowing that packed structure is CPU architecture dependent,
+# this program ignores this warning.
+#
+AM_CFLAGS			= -DK2HASH -Wno-address-of-packed-member
+AM_CPPFLAGS			= -DK2HASH -Wno-address-of-packed-member
 
 ACLOCAL_AMFLAGS		= -I m4
 

--- a/lib/k2hattrs.h
+++ b/lib/k2hattrs.h
@@ -137,8 +137,16 @@ class K2HAttrs
 //---------------------------------------------------------
 // Class K2HAttrIterator
 //---------------------------------------------------------
+// [NOTE]
+// Branched for CentOS7 support.
+//
+#if __GNUC__ > 5
+// cppcheck-suppress copyCtorAndEqOperator
+class K2HAttrIterator
+#else
 // cppcheck-suppress copyCtorAndEqOperator
 class K2HAttrIterator : public std::iterator<std::forward_iterator_tag, K2HATTR>
+#endif
 {
 		friend class K2HAttrs;
 		friend class K2HShm;
@@ -149,6 +157,15 @@ class K2HAttrIterator : public std::iterator<std::forward_iterator_tag, K2HATTR>
 
 		const K2HAttrs*			pK2HAttrs;
 		k2hattrarr_t::iterator	iter_pos;
+
+	public:
+		#if __GNUC__ > 5
+		using iterator_category	= std::random_access_iterator_tag;
+		using value_type		= K2HATTR;
+		using difference_type	= std::ptrdiff_t;
+		using pointer			= value_type*;
+		using reference			= value_type&;
+		#endif
 
 	public:
 		K2HAttrIterator(const K2HAttrIterator& iterator);

--- a/lib/k2hfind.h
+++ b/lib/k2hfind.h
@@ -31,8 +31,16 @@ class K2HShm;
 //---------------------------------------------------------
 // Class K2HIterator
 //---------------------------------------------------------
+// [NOTE]
+// Branched for CentOS7 support.
+//
+#if __GNUC__ > 5
+// cppcheck-suppress copyCtorAndEqOperator
+class K2HIterator
+#else
 // cppcheck-suppress copyCtorAndEqOperator
 class K2HIterator : public std::iterator<std::forward_iterator_tag, PELEMENT>
+#endif
 {
 		friend class K2HShm;
 
@@ -46,6 +54,15 @@ class K2HIterator : public std::iterator<std::forward_iterator_tag, PELEMENT>
 		PELEMENT		pEmptyElement;		// for dummy element
 		K2HLock			ALObjCKI;
 		K2HShmUpdater*	pShmUpdater;		// For blocking check monitor file
+
+	public:
+		#if __GNUC__ > 5
+		using iterator_category	= std::random_access_iterator_tag;
+		using value_type		= PELEMENT;
+		using difference_type	= std::ptrdiff_t;
+		using pointer			= value_type*;
+		using reference			= value_type&;
+		#endif
 
 	public:
 		K2HIterator(const K2HIterator& other);

--- a/lib/k2hpagefile.cc
+++ b/lib/k2hpagefile.cc
@@ -32,6 +32,8 @@ using namespace std;
 //---------------------------------------------------------
 // Class Methods
 //---------------------------------------------------------
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameter
 bool K2HPageFile::GetData(const K2HShm* pk2hshm, int fd, off_t offset, unsigned char** ppPageData, size_t* pLength)
 {
 	if(!ppPageData || !pLength){

--- a/lib/k2hpagemem.cc
+++ b/lib/k2hpagemem.cc
@@ -30,6 +30,8 @@ using namespace std;
 //---------------------------------------------------------
 // Class Methods
 //---------------------------------------------------------
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameter
 bool K2HPageMem::GetData(const K2HShm* pk2hshm, PPAGEHEAD reladdr, unsigned char** ppPageData, size_t* pLength)
 {
 	if(!pk2hshm || !ppPageData || !pLength){

--- a/lib/k2hshm.h
+++ b/lib/k2hshm.h
@@ -309,7 +309,7 @@ class K2HShm
 
 		// Initializing(static)
 		static bool InitializeFileZero(int fd, off_t start, size_t length);
-		static bool InitializeKeyIndexArray(void* pCKIndexShmBase, PKINDEX pKeyIndex, k2h_hash_t& start_hash, k2h_hash_t cur_mask, int cmask_bitcnt, PCKINDEX pCKIndex, int count, long default_assign);
+		static bool InitializeKeyIndexArray(void* pCKIndexShmBase, PKINDEX pKeyIndex, k2h_hash_t& start_hash, k2h_hash_t cur_mask, int cmask_bitcnt, const PCKINDEX pCKIndex, int count, long default_assign);
 		static bool InitializeCollisionKeyIndexArray(PCKINDEX pCKIndex, int count);
 		static bool InitializeElementArray(void* pShmBase, PELEMENT pElement, int count, PELEMENT pLastRelElement = NULL);
 		static bool InitializePageArray(int fd, off_t start, ssize_t pagesize, int count, PPAGEHEAD pLastRelPage = NULL);

--- a/lib/k2hshmdump.cc
+++ b/lib/k2hshmdump.cc
@@ -139,14 +139,16 @@ bool K2HShm::Dump(FILE* stream, int dumpmask) const
 		DUMP_PRINT_NV(stream, nest, "Max element cnt",	NULL, "= %p(%lu)\n",		reinterpret_cast<void*>(pHead->max_element_count), pHead->max_element_count);
 		DUMP_LOWPRINT(stream, nest, "Last update {\n");
 		nest++;
-		DUMP_PRINT_NV(stream, nest, "Date",				NULL, "= %s",				ctime_r(&(pHead->last_update.tv_sec), szTime));
+		time_t	tmp_tv_sec = pHead->last_update.tv_sec;
+		DUMP_PRINT_NV(stream, nest, "Date",				NULL, "= %s",				ctime_r(&tmp_tv_sec, szTime));
 		DUMP_PRINT_NV(stream, nest, "sec",				NULL, "= %jd\n",			static_cast<intmax_t>(pHead->last_update.tv_sec));
 		DUMP_PRINT_NV(stream, nest, "usec",				NULL, "= %jd\n",			static_cast<intmax_t>(pHead->last_update.tv_usec));
 		nest--;
 		DUMP_LOWPRINT(stream, nest, "}\n");
 		DUMP_LOWPRINT(stream, nest, "Last area update {\n");
 		nest++;
-		DUMP_PRINT_NV(stream, nest, "Date",				NULL, "= %s",				ctime_r(&(pHead->last_area_update.tv_sec), szTime));
+		tmp_tv_sec = pHead->last_area_update.tv_sec;
+		DUMP_PRINT_NV(stream, nest, "Date",				NULL, "= %s",				ctime_r(&tmp_tv_sec, szTime));
 		DUMP_PRINT_NV(stream, nest, "sec",				NULL, "= %jd\n",			static_cast<intmax_t>(pHead->last_area_update.tv_sec));
 		DUMP_PRINT_NV(stream, nest, "usec",				NULL, "= %jd\n",			static_cast<intmax_t>(pHead->last_area_update.tv_usec));
 		nest--;

--- a/lib/k2hshminit.cc
+++ b/lib/k2hshminit.cc
@@ -83,7 +83,7 @@ bool K2HShm::InitializeFileZero(int fd, off_t start, size_t length)
 	return true;
 }
 
-bool K2HShm::InitializeKeyIndexArray(void* pCKIndexShmBase, PKINDEX pKeyIndex, k2h_hash_t& start_hash, k2h_hash_t cur_mask, int cmask_bitcnt, PCKINDEX pCKIndex, int count, long default_assign)
+bool K2HShm::InitializeKeyIndexArray(void* pCKIndexShmBase, PKINDEX pKeyIndex, k2h_hash_t& start_hash, k2h_hash_t cur_mask, int cmask_bitcnt, const PCKINDEX pCKIndex, int count, long default_assign)
 {
 	if(!pCKIndexShmBase || !pKeyIndex || !pCKIndex){
 		ERR_K2HPRN("pSHmBase or PKINDEX or PCKINDEX is null");

--- a/lib/k2hsubkeys.cc
+++ b/lib/k2hsubkeys.cc
@@ -380,7 +380,7 @@ K2HSKIterator::K2HSKIterator(const K2HSubKeys* pK2HSKeys, skeyarr_t::iterator po
 {
 }
 
-K2HSKIterator::K2HSKIterator(const K2HSKIterator& iterator) : pK2HSubKeys(iterator.pK2HSubKeys), iter_pos(iterator.iter_pos)
+K2HSKIterator::K2HSKIterator(const K2HSKIterator& iterator) : pK2HSubKeys(iterator.pK2HSubKeys), iter_pos(iterator.iter_pos), dummy()
 {
 }
 

--- a/lib/k2hsubkeys.h
+++ b/lib/k2hsubkeys.h
@@ -116,8 +116,16 @@ class K2HSubKeys
 //---------------------------------------------------------
 // Class K2HSKIterator
 //---------------------------------------------------------
+// [NOTE]
+// Branched for CentOS7 support.
+//
+#if __GNUC__ > 5
+// cppcheck-suppress copyCtorAndEqOperator
+class K2HSKIterator
+#else
 // cppcheck-suppress copyCtorAndEqOperator
 class K2HSKIterator : public std::iterator<std::forward_iterator_tag, SUBKEY>
+#endif
 {
 		friend class K2HSubKeys;
 		friend class K2HShm;
@@ -127,6 +135,15 @@ class K2HSKIterator : public std::iterator<std::forward_iterator_tag, SUBKEY>
 		const K2HSubKeys*	pK2HSubKeys;
 		skeyarr_t::iterator	iter_pos;
 		SUBKEY				dummy;
+
+	public:
+		#if __GNUC__ > 5
+		using iterator_category	= std::random_access_iterator_tag;
+		using value_type		= SUBKEY;
+		using difference_type	= std::ptrdiff_t;
+		using pointer			= value_type*;
+		using reference			= value_type&;
+		#endif
 
 	public:
 		K2HSKIterator(const K2HSKIterator& iterator);

--- a/tests/k2hbench.cc
+++ b/tests/k2hbench.cc
@@ -1065,7 +1065,7 @@ static int RunChild(string cntlfile)
 			continue;
 		}
 	}
-	K2H_Delete(pthparam);
+	delete [] pthparam;
 
 	// exit
 	return EXIT_SUCCESS;
@@ -1291,7 +1291,7 @@ int main(int argc, char** argv)
 		// set measurement timespec
 		get_nomotonic_time(realtime, realstart);
 
-		K2H_Delete(pthparam);
+		delete [] pthparam;
 
 		// detach k2hash file
 		pk2hshm->Detach();

--- a/tests/k2himport.cc
+++ b/tests/k2himport.cc
@@ -42,7 +42,7 @@ void usage()
 	exit(EXIT_FAILURE) ;
 }
 
-bool isExistOption(int argc, char **argv, const string& target)
+bool isExistOption(int argc, const char **argv, const string& target)
 {
 	bool answer = false ;
 	for (int i = 1 ; i < argc; i++)
@@ -57,7 +57,7 @@ bool isExistOption(int argc, char **argv, const string& target)
 }
 
 #define MINPARAMATERS	3
-int CheckParamater(int argc, char **argv)
+int CheckParamater(int argc, const char **argv)
 {
 
 	int Answer = MODE_TSV ;
@@ -119,7 +119,7 @@ int ConvertfromMdbm(ifstream *ifs, K2HShm *k2hash)
 // -----------------------------------------
 // Main
 // -----------------------------------------
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
 	int convertmode = CheckParamater(argc, argv) ;
 	string modename ;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
- Enabled to customize variables in configure.ac  
If the configure.custom file exists, it will be loaded.  
(currently unused but added to increase availability)
- Fixed an error output by cppcheck 2.7(etc)
- Fixed CentOS 8 build failing.  
It was caused by changing the mirror, so I fixed it.
- Ignore address-of-packed-member warning by GCC 9 

