### PR TITLE
Removed K2HATTR_ENC_TYPE environment for building

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -77,11 +77,6 @@ IS_OS_ALPINE=0
 #----------------------------------------------------------
 # Variables for each OS Type
 #----------------------------------------------------------
-#
-# special variables for all
-#
-export K2HATTR_ENC_TYPE=AES256_PBKDF2
-
 if [ -z "${CI_OSTYPE}" ]; then
 	#
 	# Unknown OS : Nothing to do

--- a/buildutils/Dockerfile.templ.in
+++ b/buildutils/Dockerfile.templ.in
@@ -48,7 +48,6 @@ MAINTAINER antpickax
 WORKDIR /
 
 %%BUILD_ENV%%
-ENV K2HATTR_ENC_TYPE=AES256_PBKDF2
 
 RUN set -x && \
 	%%PKG_UPDATE%% && \


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Removed the K2HATTR_ENC_TYPE environment variable specified for building, because it specifies the same value as the default.

