### PR TITLE
Fixed .gitignore to exclude APKBUILD.templ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ Makefile.in
 Makefile
 Dockerfile
 buildutils/Dockerfile.templ
+buildutils/APKBUILD.templ
 
 #
 # archive files and backups


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Fixed leaking `buildutils/APKBUILD.templ` in `.gitignore`.