### PR TITLE
Avoided latest cppcheck error which maybe a false positive

### DIFF
--- a/lib/k2hshmcomp.cc
+++ b/lib/k2hshmcomp.cc
@@ -141,6 +141,8 @@ PELEMENT K2HShm::ReserveElement(void* pRelExpArea, size_t ExpLength)
 	}
 	K2HLock		ALObjFEC(ShmFd, Rel(&(pHead->free_element_count)), K2HLock::RWLOCK);	// LOCK
 
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress constVariablePointer
 	const PELEMENT	pStartPos	= reinterpret_cast<PELEMENT>(pRelExpArea);
 	// cppcheck-suppress unmatchedSuppression
 	// cppcheck-suppress constVariablePointer


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The latest cppcheck(v2.11 or 2.14 or later) is falsely detecting a `constVariablePointer` error when specifying `const` using the typedef name of a structure pointer.
Therefore, avoided this by adding an inline suppress.